### PR TITLE
Summary of Changes

### DIFF
--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -1,11 +1,44 @@
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
-import { Observable } from 'rxjs';
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
+import { ROLES_KEY } from './roles.decorator';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  canActivate(
-    context: ExecutionContext,
-  ): boolean | Promise<boolean> | Observable<boolean> {
-    return true;
+  constructor(
+    private reflector: Reflector,
+    private jwtService: JwtService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    const req = context.switchToHttp().getRequest<Request>();
+    const token = req.headers.authorization?.split(' ')[1];
+
+    if (!token) throw new UnauthorizedException('Token missing');
+
+    try {
+      const user = await this.jwtService.verifyAsync(token);
+      req.user = user;
+
+      if (requiredRoles && !requiredRoles.includes(user.role)) {
+        throw new ForbiddenException('Access denied');
+      }
+
+      return true;
+    } catch (err) {
+      throw new UnauthorizedException('Invalid token');
+    }
   }
 }

--- a/src/roles/roles.guard.ts
+++ b/src/roles/roles.guard.ts
@@ -1,7 +1,10 @@
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable,  UnauthorizedException,
+  ForbiddenException,} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { UserRole } from '../users/user.entity';
 import { ROLES_KEY } from './roles.decorator';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
@@ -13,6 +16,8 @@ export class RolesGuard implements CanActivate {
       context.getClass(),
     ]);
     if (!requiredRoles) return true;
+
+    if (!token) throw new UnauthorizedException('Token missing');
 
     const { user } = context.switchToHttp().getRequest();
     return requiredRoles.includes(user?.role);

--- a/src/users/employees.controller.ts
+++ b/src/users/employees.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Roles } from '../auth/roles.decorator';
+import { AuthGuard } from '../auth/auth.guard';
+import { EmployeesService } from './employees.service';
+
+@Controller('employees')
+@UseGuards(AuthGuard)
+export class EmployeesController {
+  constructor(private readonly employeesService: EmployeesService) {}
+
+  @Get()
+  @Roles('admin')
+  async getEmployees(
+    @Query('page') page = '1',
+    @Query('limit') limit = '10',
+  ) {
+    const pageNum = parseInt(page);
+    const pageSize = parseInt(limit);
+    return this.employeesService.getPaginatedEmployees(pageNum, pageSize);
+  }
+}

--- a/src/users/employees.service.ts
+++ b/src/users/employees.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service'; // Replace if using TypeORM or Mongoose
+
+@Injectable()
+export class EmployeesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getPaginatedEmployees(page: number, limit: number) {
+    const skip = (page - 1) * limit;
+
+    const [employees, totalCount] = await Promise.all([
+      this.prisma.user.findMany({
+        where: { role: 'employee' },
+        skip,
+        take: limit,
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          status: true,
+          role: true,
+        },
+      }),
+      this.prisma.user.count({ where: { role: 'employee' } }),
+    ]);
+
+    return {
+      page,
+      limit,
+      totalCount,
+      employees,
+    };
+  }
+}


### PR DESCRIPTION
Added a new GET /employees endpoint to fetch a paginated list of employees (role: employee).

The endpoint is admin-only, restricted using JWT authentication and role-based access control via a custom AuthGuard.

Pagination is supported through page and limit query parameters.

The EmployeesService handles fetching employee data using Prisma, ensuring only relevant fields are returned.

Admin access is controlled using the Roles decorator and AuthGuard, ensuring that only users with the admin role can access the route.

This implementation provides secure access to employee data with efficient pagination.